### PR TITLE
Viewshed

### DIFF
--- a/cdistance/src/main/resources/log4j.properties
+++ b/cdistance/src/main/resources/log4j.properties
@@ -7,4 +7,5 @@ log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - 
 # http://stackoverflow.com/questions/23869207/what-is-the-significance-of-log4j-rootlogger-property-in-log4j-properties-file
 log4j.logger.com.example.cdistance=DEBUG
 log4j.logger.geotrellis.spark.costdistance=DEBUG
+log4j.logger.geotrellis.spark.viewshed=DEBUG
 log4j.category.org.geoserver.platform=ERROR

--- a/cdistance/src/main/scala/CostDistance.scala
+++ b/cdistance/src/main/scala/CostDistance.scala
@@ -67,8 +67,10 @@ object CostDistance {
       val y = args(6).toDouble
       val z = args(7).toDouble
       val maxDistance = args(8).toDouble
+      val and = ((args.length > 9) && (args(9) == "AND"))
+      val andOr = if (and) "AND"; else "OR"
 
-      logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId ($x, $y, $z) maxDistance=$maxDistance")
+      logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId ($x, $y, $z) maxDistance=$maxDistance $andOr")
 
       // Read elevation layer
       val elevation =
@@ -77,7 +79,7 @@ object CostDistance {
 
       // Compute viewshed layer
       val before = System.currentTimeMillis
-      val viewshed = IterativeViewshed(elevation, Point(x, y), z, maxDistance)
+      val viewshed = IterativeViewshed(elevation, Point(x, y), z, maxDistance, and)
       val after = System.currentTimeMillis
 
       logger.info(s"${after - before} milliseconds")

--- a/cdistance/src/main/scala/CostDistance.scala
+++ b/cdistance/src/main/scala/CostDistance.scala
@@ -3,11 +3,11 @@ package com.example.cdistance
 import geotrellis.geotools._
 import geotrellis.proj4.WebMercator
 import geotrellis.raster._
-import geotrellis.raster.costdistance._
+// import geotrellis.raster.costdistance._
 import geotrellis.raster.io._
 import geotrellis.shapefile._
 import geotrellis.spark._
-import geotrellis.spark.costdistance._
+// import geotrellis.spark.costdistance._
 import geotrellis.spark.io._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.index._
@@ -92,36 +92,36 @@ object CostDistance {
       logger.info(s"Writing to $catalog $writeId")
       HadoopLayerWriter(catalog).write(writeId, slope, ZCurveKeyIndexMethod)
     }
-    // COST-DISTANCE COMMAND
-    else if (operation == "costdistance") {
-      val zoom = args(4).toInt
-      val readId = LayerId(args(2), zoom)
-      val writeId = LayerId(args(3), zoom)
-      val shapeFile = args(5)
-      val maxCost = args(6).toDouble
+    // // COST-DISTANCE COMMAND
+    // else if (operation == "costdistance") {
+    //   val zoom = args(4).toInt
+    //   val readId = LayerId(args(2), zoom)
+    //   val writeId = LayerId(args(3), zoom)
+    //   val shapeFile = args(5)
+    //   val maxCost = args(6).toDouble
 
-      logger.debug(s"Cost-Distance: catalog=$catalog input=$readId output=$writeId shapeFile=$shapeFile maxCost=$maxCost")
+    //   logger.debug(s"Cost-Distance: catalog=$catalog input=$readId output=$writeId shapeFile=$shapeFile maxCost=$maxCost")
 
-      // Read friction layer
-      val friction =
-        HadoopLayerReader(catalog)
-          .read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](readId)
+    //   // Read friction layer
+    //   val friction =
+    //     HadoopLayerReader(catalog)
+    //       .read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](readId)
 
-      // Read starting points
-      val points: List[Point] =
-        ShapeFileReader
-          .readSimpleFeatures(shapeFile)
-          .map({ sf => sf.toGeometry[Point] })
+    //   // Read starting points
+    //   val points: List[Point] =
+    //     ShapeFileReader
+    //       .readSimpleFeatures(shapeFile)
+    //       .map({ sf => sf.toGeometry[Point] })
 
-      // Compute cost layer
-      val before = System.currentTimeMillis
-      val cost = friction.costdistance(points, maxCost)
-      val after = System.currentTimeMillis
+    //   // Compute cost layer
+    //   val before = System.currentTimeMillis
+    //   val cost = friction.costdistance(points, maxCost)
+    //   val after = System.currentTimeMillis
 
-      logger.info(s"${after - before} milliseconds")
-      logger.info(s"Writing to $catalog $writeId")
-      HadoopLayerWriter(catalog).write(writeId, cost, ZCurveKeyIndexMethod)
-    }
+    //   logger.info(s"${after - before} milliseconds")
+    //   logger.info(s"Writing to $catalog $writeId")
+    //   HadoopLayerWriter(catalog).write(writeId, cost, ZCurveKeyIndexMethod)
+    // }
     // DUMP COMMAND
     else if (operation == "dump") {
       val layerName = args(2)

--- a/cdistance/src/main/scala/CostDistance.scala
+++ b/cdistance/src/main/scala/CostDistance.scala
@@ -75,9 +75,9 @@ object CostDistance {
       }
 
       val points = args.drop(7)
-        .grouped(5)
+        .grouped(6)
         .toList
-        .map({ case ar: Array[String] if (ar.length == 5) => ar.map(_.toDouble) })
+        .map({ case ar: Array[String] if (ar.length == 6) => ar.map(_.toDouble) })
 
       logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId maxDistance=$maxDistance op=$op points=${points.map(_.toList)}")
 

--- a/cdistance/src/main/scala/CostDistance.scala
+++ b/cdistance/src/main/scala/CostDistance.scala
@@ -66,8 +66,9 @@ object CostDistance {
       val x = args(5).toDouble
       val y = args(6).toDouble
       val z = args(7).toDouble
+      val maxDistance = args(8).toDouble
 
-      logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId ($x, $y, $z)")
+      logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId ($x, $y, $z) maxDistance=$maxDistance")
 
       // Read elevation layer
       val elevation =
@@ -76,7 +77,7 @@ object CostDistance {
 
       // Compute viewshed layer
       val before = System.currentTimeMillis
-      val viewshed = IterativeViewshed(elevation, Point(x, y), z)
+      val viewshed = IterativeViewshed(elevation, Point(x, y), z, maxDistance)
       val after = System.currentTimeMillis
 
       logger.info(s"${after - before} milliseconds")

--- a/cdistance/src/main/scala/CostDistance.scala
+++ b/cdistance/src/main/scala/CostDistance.scala
@@ -69,17 +69,17 @@ object CostDistance {
       val maxDistance = args(5).toDouble
       val op = args(6) match {
         case "AND" => And()
+        case "DEBUG" => Debug()
         case "OR" => Or()
         case "PLUS" => Plus()
-        case "U.PLUS" => UniquePlus()
       }
 
       val points = args.drop(7)
-        .grouped(3)
+        .grouped(5)
         .toList
-        .map({ case Array(x, y, z) => new jts.Coordinate(x.toDouble, y.toDouble, z.toDouble) })
+        .map({ case ar: Array[String] if (ar.length == 5) => ar.map(_.toDouble) })
 
-      logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId maxDistance=$maxDistance op=$op points=${points}")
+      logger.debug(s"Viewshed: catalog=$catalog input=$readId output=$writeId maxDistance=$maxDistance op=$op points=${points.map(_.toList)}")
 
       // Read elevation layer
       val elevation =
@@ -88,7 +88,12 @@ object CostDistance {
 
       // Compute viewshed layer
       val before = System.currentTimeMillis
-      val viewshed = IterativeViewshed(elevation, points, maxDistance, op)
+      val viewshed = IterativeViewshed(
+        elevation, points,
+        maxDistance = maxDistance,
+        curvature = true,
+        operator = op
+      )
       val after = System.currentTimeMillis
 
       logger.info(s"${after - before} milliseconds")


### PR DESCRIPTION
```
src/CostDistance% time $SPARK_HOME/bin/spark-submit --master 'local[*]' --driver-memory 16G cdistance/target/scala-2.11/cdistance-assembly-0.jar 'file:///tmp/hdfs-catalog' viewshed ned shed 9 250000 PLUS -10940657 4501659 4000 0.785 0.707 0 -10877415 4448309 4000 0.0 -0.707 33 -10649302 4259707 2000 3.14 0 0
13 Mar 16:27:30 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
13 Mar 16:27:30 WARN [util.Utils] - Your hostname, beijing resolves to a loopback address: 127.0.1.1; using 172.26.100.4 instead (on interface eth0)
13 Mar 16:27:30 WARN [util.Utils] - Set SPARK_LOCAL_IP if you need to bind to another address
13 Mar 16:27:31 DEBUG [cdistance.CostDistance$] - Viewshed: catalog=file:///tmp/hdfs-catalog input=Layer(name = "ned", zoom = 9) output=Layer(name = "shed", zoom = 9) maxDistance=250000.0 op=PLUS points=List(List(-1.0940657E7, 4501659.0, 4000.0, 0.785, 0.707, 0.0), List(-1.0877415E7, 4448309.0, 4000.0, 0.0, -0.707, 33.0), List(-1.0649302E7, 4259707.0, 2000.0, 3.14, 0.0, 0.0))
13 Mar 16:27:34 DEBUG [viewshed.IterativeViewshed$] - Computed resolution: 305.748113140705 meters/pixel
13 Mar 16:27:52 DEBUG [viewshed.IterativeViewshed$] - ≥ 7 tiles in motion       
13 Mar 16:27:55 DEBUG [viewshed.IterativeViewshed$] - ≥ 11 tiles in motion      
13 Mar 16:27:58 DEBUG [viewshed.IterativeViewshed$] - ≥ 18 tiles in motion      
13 Mar 16:28:02 DEBUG [viewshed.IterativeViewshed$] - ≥ 22 tiles in motion      
13 Mar 16:28:04 DEBUG [viewshed.IterativeViewshed$] - ≥ 23 tiles in motion      
13 Mar 16:28:07 DEBUG [viewshed.IterativeViewshed$] - ≥ 13 tiles in motion      
13 Mar 16:28:10 DEBUG [viewshed.IterativeViewshed$] - ≥ 2 tiles in motion       
13 Mar 16:28:12 INFO [cdistance.CostDistance$] - 39543 milliseconds             
13 Mar 16:28:12 INFO [cdistance.CostDistance$] - Writing to file:///tmp/hdfs-catalog Layer(name = "shed", zoom = 9)
$SPARK_HOME/bin/spark-submit --master 'local[*]' --driver-memory 16G    ned    591.31s user 49.22s system 1245% cpu 51.425 total
```

![screenshot from 2017-03-13 16 32 06](https://cloud.githubusercontent.com/assets/11281373/23874257/494edea6-080b-11e7-9794-67b14375c80a.png)
